### PR TITLE
Allow configuring bucket and IAM role for Phlare

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -18,6 +18,7 @@ locals {
   cert_manager_role_name                 = "cert-manager-${var.name}"                       // The name of the IAM role to be used by 'cert-manager'.
   cluster_autoscaler_role_name           = "cluster-autoscaler-${var.name}"                 // The name of the IAM role to be used by 'cluster-autoscaler'.
   external_dns_role_name                 = "external-dns-${var.name}"                       // The name of the IAM role to be used by 'external-dns'.
+  phlare_role_name                       = "phlare-${var.name}"                             // The name of the IAM role to be used by Phlare.
   iam_path                               = "/"                                              // The path in which to create IAM resources.
   log_shipping_role_name                 = "log-shipping-${var.name}"                       // The name of the IAM role to be used by any log-shipping component(s).
   path_to_kubeconfig_file                = abspath("${path.module}/${var.name}.kubeconfig") // The path to the kubeconfig file that will be created and output.

--- a/variables.tf
+++ b/variables.tf
@@ -105,6 +105,18 @@ variable "log_shipping_oidc_fully_qualified_subjects" {
   type        = list(string)
 }
 
+variable "phlare_bucket_name" {
+  default     = ""
+  description = "The name of the S3 bucket that will be used by Phlare"
+  type        = string
+}
+
+variable "phlare_oidc_fully_qualified_subjects" {
+  description = "The list of trusted resources which can assume the 'phlare' role using OpenID Connect."
+  default     = []
+  type        = list(string)
+}
+
 variable "manage_aws_auth_configmap" {
   description = "Whether the upstream 'terraform-aws-eks' module should manage the 'kube-system/aws-auth' configmap. If using Flux, this should probably be 'false'. If not, this should probably be set to 'true'."
   type        = bool


### PR DESCRIPTION
Grafana has another product in the observability space  called Phlare which can periodically scrape pprof profiles from applications, which could be incredibly useful for debugging issues with Cilium and other components. Like the rest of the LGTM stack, it requires object storage, so this commit adds the option to create another bucket for storing profiles.

Signed-off-by: Chance Zibolski <chance.zibolski@gmail.com>