### PR TITLE
Add oidc_provider_arn output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -66,3 +66,7 @@ output "ssh_private_key_pem" {
   sensitive = true
   value     = tls_private_key.ssh_key.private_key_pem
 }
+
+output "oidc_provider_arn" {
+  value = module.main.oidc_provider_arn
+}


### PR DESCRIPTION
Needed for downstream consumers of the module to get the OIDC provider for use with IRSA.