### PR TITLE
S3 ACL fixed.

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -29,6 +29,7 @@ resource "aws_s3_bucket_acl" "log_shipping" {
 }
 
 resource "aws_s3_bucket_ownership_controls" "log_shipping_ownership_controls" {
+  count  = length(var.log_shipping_oidc_fully_qualified_subjects) > 0 ? 1 : 0 // Only actually create the ACL if a service account used for log shipping has been specified.
   bucket = aws_s3_bucket.log_shipping[0].id
   rule {
     object_ownership = "ObjectWriter"
@@ -62,6 +63,7 @@ resource "aws_s3_bucket_acl" "phlare" {
 }
 
 resource "aws_s3_bucket_ownership_controls" "phlare_ownership_controls" {
+  count  = length(var.phlare_oidc_fully_qualified_subjects) > 0 ? 1 : 0 // Only actually create the ACL if a service account used for log shipping has been specified.
   bucket = aws_s3_bucket.phlare[0].id
   rule {
     object_ownership = "ObjectWriter"
@@ -120,6 +122,7 @@ resource "aws_s3_bucket_acl" "velero" {
 }
 
 resource "aws_s3_bucket_ownership_controls" "velero_ownership_controls" {
+  count  = length(var.velero_oidc_fully_qualified_subjects) > 0 ? 1 : 0 // Only actually create the ACL if a service account used for log shipping has been specified.
   bucket = aws_s3_bucket.velero[0].id
   rule {
     object_ownership = "ObjectWriter"


### PR DESCRIPTION
Fix for the below error:

╷
│ Error: Invalid index
│ 
│   on .terraform/modules/alpo_1_eks/s3.tf line 65, in resource "aws_s3_bucket_ownership_controls" "phlare_ownership_controls":
│   65:   bucket = aws_s3_bucket.phlare[0].id
│     ├────────────────
│     │ aws_s3_bucket.phlare is empty tuple
│ 
│ The given key does not identify an element in this collection value: the collection has no elements.
╵