### PR TITLE
Add bottlerocket support

### DIFF
--- a/eks.tf
+++ b/eks.tf
@@ -113,12 +113,13 @@ module "main" {
   self_managed_node_groups = { // The set of self-managed node groups.
     for key, g in var.self_managed_node_groups :
     key => {
-      ami_id                = data.aws_ami.workers[key].image_id               // The ID of the AMI to use for worker nodes.
-      create_security_group = false                                            // Don't create a dedicated security group. A common one is used instead.
-      desired_size          = g.min_nodes                                      // Set the desired size of the worker group to the minimum.
-      key_name              = aws_key_pair.ssh_access.key_name                 // The name of the SSH key to use for the nodes.
-      bootstrap_extra_args  = "--kubelet-extra-args '${g.kubelet_extra_args}'" // The set of extra arguments to the bootstrap script. Used to pass extra flags to the kubelet, and namely to set labels and taints.
-      iam_role_additional_policies = {                                         // The set of additional policies to add to the worker group IAM role.
+      platform              = g.platform
+      ami_id                = data.aws_ami.workers[key].image_id                                                   // The ID of the AMI to use for worker nodes.
+      create_security_group = false                                                                                // Don't create a dedicated security group. A common one is used instead.
+      desired_size          = g.min_nodes                                                                          // Set the desired size of the worker group to the minimum.
+      key_name              = aws_key_pair.ssh_access.key_name                                                     // The name of the SSH key to use for the nodes.
+      bootstrap_extra_args  = g.platform == "bottlerocket" ? "" : "--kubelet-extra-args '${g.kubelet_extra_args}'" // The set of extra arguments to the bootstrap script. Used to pass extra flags to the kubelet, and namely to set labels and taints.
+      iam_role_additional_policies = {                                                                             // The set of additional policies to add to the worker group IAM role.
         for index, arn in var.worker_node_additional_policies :
         arn => arn
       }

--- a/variables.tf
+++ b/variables.tf
@@ -141,6 +141,7 @@ variable "region" {
 variable "self_managed_node_groups" {
   description = "A map describing the set of self-managed node groups to create. Other types of node groups besides self-managed are currently not supported."
   type = map(object({
+    platform                     = string
     ami_name_filter              = string
     extra_tags                   = map(string)
     instance_type                = string


### PR DESCRIPTION
Bottlerocket uses different user data format, can be provided via platform attribute:
```
self_managed_node_groups = {
    # Bottlerocket node group
    bottlerocket = {
      name = "bottlerocket-self-mng"
      platform      = "bottlerocket" <<<
```
https://github.com/terraform-aws-modules/terraform-aws-eks/blob/v19.16.0/examples/self_managed_node_group/main.tf

It's for Immuta CUTE, they use Bottlerocket