### PR TITLE
using provider so we can use eks module to manage the authconfigmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ An opinionated Terraform module that can be used to create and manage an EKS clu
 | [aws_security_group_rule.workers_to_workers_ingress_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [null_resource.disable_aws_vpc_cni_plugin](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.kubeconfig](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [null_resource.update_aws_auth_configmap](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.wait_for_control_plane_subnets](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [tls_private_key.ssh_key](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
 | [aws_ami.ubuntu](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |

--- a/terraform.tf
+++ b/terraform.tf
@@ -29,3 +29,15 @@ terraform {
   }
   required_version = ">= 1.3.0"
 }
+
+provider "kubernetes" {
+  host                   = module.main.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.main.cluster_certificate_authority_data)
+
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    # This requires the awscli to be installed locally where Terraform is executed
+    args = ["eks", "get-token", "--cluster-name", module.main.cluster_name]
+  }
+}


### PR DESCRIPTION
using provider so we can use eks module to manage the authconfigmap otherwise, we can't change the node group once we deploy the eks clusters