### PR TITLE
change the  to use kubelet_extra_args for bottlerocket

### DIFF
--- a/eks.tf
+++ b/eks.tf
@@ -113,13 +113,13 @@ module "main" {
   self_managed_node_groups = { // The set of self-managed node groups.
     for key, g in var.self_managed_node_groups :
     key => {
-      platform              = coalesce(g.platform, "linux")                                                        // Platform is optional, linux is used if omitted, also can be bottlerocket or windows https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/user_data.md#user-data--bootstrapping 
-      ami_id                = data.aws_ami.workers[key].image_id                                                   // The ID of the AMI to use for worker nodes.
-      create_security_group = false                                                                                // Don't create a dedicated security group. A common one is used instead.
-      desired_size          = g.min_nodes                                                                          // Set the desired size of the worker group to the minimum.
-      key_name              = aws_key_pair.ssh_access.key_name                                                     // The name of the SSH key to use for the nodes.
-      bootstrap_extra_args  = g.platform == "bottlerocket" ? "" : "--kubelet-extra-args '${g.kubelet_extra_args}'" // The set of extra arguments to the bootstrap script. Used to pass extra flags to the kubelet, and namely to set labels and taints. Ignored for bottlerocket.
-      iam_role_additional_policies = {                                                                             // The set of additional policies to add to the worker group IAM role.
+      platform              = coalesce(g.platform, "linux")                                                                          // Platform is optional, linux is used if omitted, also can be bottlerocket or windows https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/user_data.md#user-data--bootstrapping 
+      ami_id                = data.aws_ami.workers[key].image_id                                                                     // The ID of the AMI to use for worker nodes.
+      create_security_group = false                                                                                                  // Don't create a dedicated security group. A common one is used instead.
+      desired_size          = g.min_nodes                                                                                            // Set the desired size of the worker group to the minimum.
+      key_name              = aws_key_pair.ssh_access.key_name                                                                       // The name of the SSH key to use for the nodes.
+      bootstrap_extra_args  = g.platform == "bottlerocket" ? g.kubelet_extra_args : "--kubelet-extra-args '${g.kubelet_extra_args}'" // The set of extra arguments to the bootstrap script. Used to pass extra flags to the kubelet, and namely to set labels and taints. Ignored for bottlerocket.
+      iam_role_additional_policies = {                                                                                               // The set of additional policies to add to the worker group IAM role.
         for index, arn in var.worker_node_additional_policies :
         arn => arn
       }


### PR DESCRIPTION
this is the PR so we can use `kubelet_extra_args` for bottlerocket


```
module "eks" {
  source = "../terraform-aws-eks"

  disable_aws_vpc_cni_plugin = true
  kubernetes_version         = var.kubernetes_version
  manage_aws_auth_configmap  = true
  name                       = local.cluster_name
  region                     = var.region
  tags                       = var.tags
  vpc_id                     = module.vpc.id

  self_managed_node_groups = {
    x86 = {
      platform                 = "bottlerocket"
      ami_name_filter          = var.x86_ami_name_filter
      extra_tags               = {}
      instance_type            = var.x86_worker_instance_type
      kubelet_extra_args       = <<-EOT
        [settings.host-containers.admin]
        enabled = true
        [settings.host-containers.control]
        enabled = true
        [settings.kubernetes.node-taints]
        "node.cilium.io/agent-not-ready" = "true:NoExecute"
      EOT
      max_nodes                = var.worker_max_nodes
      min_nodes                = var.worker_min_nodes
      name                     = "x86"
      post_bootstrap_user_data = ""
      pre_bootstrap_user_data  = ""
      root_volume_id           = "/dev/xvda"
      root_volume_size         = var.worker_root_volume_size
      root_volume_type         = "gp3"
      subnet_ids               = module.vpc.private_subnet_ids
      iam_role_additional_policies = {
        additional = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
      }
    },
```

Here is what I use.

I think it's better just use it this way so we dont break the exsiting kubelet_extra_args for other non-bottlerocket 