### PR TITLE
Vars: add tag_specifications to worker nodes

### DIFF
--- a/eks.tf
+++ b/eks.tf
@@ -144,9 +144,10 @@ module "main" {
       create_access_entry          = g.create_access_entry
       iam_role_arn                 = g.iam_role_arn
       subnet_ids                   = length(g.subnet_ids) > 0 ? g.subnet_ids : data.aws_subnets.private.ids // Only place nodes in private subnets. This may change in the future.
-      tags = merge(g.extra_tags, {                                                                          // The set of tags placed on each worker node.
-        "k8s.io/cluster-autoscaler/enabled"     = "true",                                                   // Required by the cluster autoscaler.
-        "k8s.io/cluster-autoscaler/${var.name}" = "owned",                                                  // Required by the cluster autoscaler.
+      launch_template_tags         = g.extra_tags
+      tags = merge(g.extra_tags, {                         // The set of tags placed on each worker node.
+        "k8s.io/cluster-autoscaler/enabled"     = "true",  // Required by the cluster autoscaler.
+        "k8s.io/cluster-autoscaler/${var.name}" = "owned", // Required by the cluster autoscaler.
       })
       block_device_mappings = {
         (g.root_volume_id) = {


### PR DESCRIPTION
This is required to ensure that the nodes created
by the ASG have the correct tags applied.